### PR TITLE
Update reposity dependency

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -13,7 +13,7 @@ supports:
 
 depends:
 - name: inspec-k8s
-  url: https://github.com/bgeesaman/inspec-k8s/archive/0.1.3.tar.gz
+  url: https://github.com/inspec/inspec-k8s/archive/refs/tags/0.1.3.tar.gz
 
 inputs:
   - name: k8s_minium_version


### PR DESCRIPTION
I was looking that when I run the scan it won't work because it was using a old repository 

`Profile URL dependency https://github.com/bgeesaman/inspec-k8s/archive/0.1.3.tar.gz could not be fetched: 404 Not Found`

With this PR the scan is working again

